### PR TITLE
Add multi-target framework support to xPak.Ext.MSSystem.WinForm.csproj

### DIFF
--- a/xPak.Ext.MSSystem.WinForm/xPak.Ext.MSSystem.WinForm.csproj
+++ b/xPak.Ext.MSSystem.WinForm/xPak.Ext.MSSystem.WinForm.csproj
@@ -1,7 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net48;net6.0-windows;net8.0-windows</TargetFrameworks>
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net48'">
+    <DefineConstants>NET48</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0-windows'">
+    <DefineConstants>NET6_0_WINDOWS;NET6_0_WINDOWS_OR_GREATER</DefineConstants>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0-windows'">
+    <DefineConstants>NET8_0_WINDOWS;NET6_0_WINDOWS_OR_GREATER;NET8_0_WINDOWS_OR_GREATER</DefineConstants>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Add multi-target framework support to xPak.Ext.MSSystem.WinForm.csproj

Updated the project file to target .NET Framework 4.8, .NET 6.0 for Windows, and .NET 8.0 for Windows. Replaced `<TargetFramework>` with `<TargetFrameworks>` and added property groups for specific settings and constants for each framework.